### PR TITLE
Default to system settings for unknown message modes

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -348,7 +348,7 @@ function ui:set_type(type)
         [146] = self._system_settings, -- "You hear something moving to the east..."
         [15] = self._system_settings, -- cutscene emote
     }
-    self._type = types[type]
+    self._type = types[type] or self._system_settings
 
     self:update_message_bg(self._type.path)
     self.message_text:alpha(self._type.color.alpha)


### PR DESCRIPTION
Use a default message mode in `ui:set_type` to avoid an error when an arbitrary chat mode is added to `settings.additional_chat_mode`.

For example, I added chat mode 148 to my settings, and when a mode 148 message is received, the following error is thrown:
```
[15:52:56] [15:52:56] [Addons] Addon 'balloon' encountered an error during an event callback 'text_in'. Error: \addons\balloon\ui.lua:353: attempt to index field '_type' (a nil value)
[15:52:56] stack traceback:
[15:52:56] 	\addons\balloon\ui.lua: in function 'set_type'
[15:52:56] 	\addons\balloon\\balloon.lua:355: in function 'process_balloon'
[15:52:56] 	\addons\balloon\\balloon.lua:219: in function 'process_incoming_message'
[15:52:56] 	\addons\balloon\\balloon.lua:707: in function <\addons\balloon\\balloon.lua:695>
```

Defaulting to `_system_settings` seemed reasonable to me. Other possibilities include logging an error message in this case, or changing the `additional_chat_mode` table to also contain to UI setting for each mode.

