### PR TITLE
Don't add spaces to punctuation; replace -- with em dashes

### DIFF
--- a/Balloon.lua
+++ b/Balloon.lua
@@ -323,6 +323,7 @@ balloon.process_balloon = function(message, mode)
     message = message:gsub(chat_color_codes.emote, '') --cutscene emote color code (handled by the message type instead)
 
     message = message:gsub('^?([%w%.\'(<“])', '%1')
+    message = message:gsub('%f[-]%-%-%f[^-]', '—') --replace -- with em dashes
 
     message = message:gsub('%[BL_c1]', '\\cr')
     message = message:gsub('%[BL_c2]', '\\cs('..ui._type.items..')')

--- a/Balloon.lua
+++ b/Balloon.lua
@@ -323,8 +323,6 @@ balloon.process_balloon = function(message, mode)
     message = message:gsub(chat_color_codes.emote, '') --cutscene emote color code (handled by the message type instead)
 
     message = message:gsub('^?([%w%.\'(<“])', '%1')
-    message = message:gsub('(%w)(%.%.%.+)([%w“])', '%1%2 %3') --add a space after elipses to allow better line splitting
-    message = message:gsub('([%w”])%-%-([%w%p])', '%1-- %2') --same for double dashes
 
     message = message:gsub('%[BL_c1]', '\\cr')
     message = message:gsub('%[BL_c2]', '\\cs('..ui._type.items..')')

--- a/tests.lua
+++ b/tests.lua
@@ -70,4 +70,14 @@ tests.bahamut = {
 €‚É‚æ‚Á‚Ä‹€‚¿‰Ê‚Ä‚½‹ë‚É‚·‚¬‚È‚¢B]],
 }
 
+tests.punctuation_wrap = {
+    'Test',
+    "--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--" ..
+    "testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--" ..
+    "foo-----testing... foo-- testing -- foo --end--",
+    "--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--" ..
+    "testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--" ..
+    "foo-----testing... foo-- testing -- foo --end--",
+}
+
 return tests


### PR DESCRIPTION
The original plugin manually handled text wrapping, and spaces were spliced in after ellipses and dashes to make the wrapping work better. This isn't necessary now that GDI is handling the wrapping, as it seems to wrap at the punctuation correctly. Removing this can avoid an unsightly extra space after dashes-- like this.

gdifonts can render the full range of Unicode, so also replace double hyphens -- with an em dash — for aesthetics.