### PR TITLE
Fix to display text in multiple lines in Linux/Wine & Steam Deck

### DIFF
--- a/wlibs/texts.lua
+++ b/wlibs/texts.lua
@@ -177,6 +177,7 @@ local function get_font_settings(settings)
         position_x = 0,
         position_y = 0,
         visible = true,
+        format = 0x0004, --DT_WORDBREAK auto break lines based on text boundaries
         text = '',
     }
     return font_settings


### PR DESCRIPTION
Hi,

Many thanks for porting this awesome add-on for Ashita v4!

Balloon works flawlessly when playing FFXI on Linux with Wine. However, there's a minor issue where only the first line of text is visible in any dialog. For example, running `/bl test punctuation_wrap` only displays the first line, such as: 
`"--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--testing...foo--"`

This small change enables text wrapping in Wine, which, as I understand, is the default behavior on Windows.

### Testing
I've tested it with multiple Wine versions: Wine-GE-8X, GE-Proton9X, and UMU-Proton-9.0, and it works great. I haven’t tested it on a Steam Deck, but it should work well there too, since it uses the same Proton/Wine libraries.

I’d appreciate some help verifying that this change doesn't cause any font rendering issues on Windows. Would you kindly lend a hand?

Kind regards